### PR TITLE
增加属性：可修改绑定dom

### DIFF
--- a/package/component.ts
+++ b/package/component.ts
@@ -79,6 +79,10 @@ export default defineComponent({
     bodyOverflowHidden: {
       type: Boolean,
       default: true
+    },
+    target: {
+      type: String,
+      default: null
     }
   },
   setup(props, { slots }) {
@@ -161,8 +165,9 @@ export default defineComponent({
       if (!props.autoScale) return
       const domWidth = el.value!.clientWidth
       const domHeight = el.value!.clientHeight
-      const currentWidth = document.body.clientWidth
-      const currentHeight = document.body.clientHeight
+      const targetElement = props.target ? document.querySelector(props.target) : document.body
+      const currentWidth = targetElement.clientWidth
+      const currentHeight = targetElement.clientHeight
       el.value!.style.transform = `scale(${scale},${scale})`
       let mx = Math.max((currentWidth - domWidth * scale) / 2, 0)
       let my = Math.max((currentHeight - domHeight * scale) / 2, 0)
@@ -174,8 +179,9 @@ export default defineComponent({
     }
     const updateScale = () => {
       // 获取真实视口尺寸
-      const currentWidth = document.body.clientWidth
-      const currentHeight = document.body.clientHeight
+      const targetElement = props.target ? document.querySelector(props.target) : document.body
+      const currentWidth = targetElement.clientWidth
+      const currentHeight = targetElement.clientHeight
       // 获取大屏最终的宽高
       const realWidth = state.width || state.originalWidth
       const realHeight = state.height || state.originalHeight


### PR DESCRIPTION
默认是绑定到body，通过设置target可绑定到外层dom上，比如页面上方有顶部工具栏、左侧有菜单栏，或者组件嵌入其他页面等情况。

<div class="page" style="width:100%;height:100%">
<v-scale-screen target=".page"></v-scale-screen>
</div>